### PR TITLE
Don’t create newlines after merge

### DIFF
--- a/cypress/integration/complex-merge.spec.js
+++ b/cypress/integration/complex-merge.spec.js
@@ -1,0 +1,37 @@
+describe('Ace-diff API', () => {
+  beforeEach(() => {
+    cy.visit('http://localhost:8081/test/fixtures/complex-merge.html');
+  });
+
+  context('Merging complex diff from the left', () => {
+    it('shows 1 diff', () => {
+      cy.window().then((win) => {
+        expect(win.aceDiffer.getNumDiffs()).to.equal(1);
+      });
+    });
+
+    it('it shows 0 diffs after merging', () => {
+      cy.get('.acediff__deletedCodeConnector').click();
+
+      cy.window().then((win) => {
+        expect(win.aceDiffer.getNumDiffs()).to.equal(0);
+      });
+    });
+  });
+
+  context('Merging complex diff from the right', () => {
+    it('shows 1 diff', () => {
+      cy.window().then((win) => {
+        expect(win.aceDiffer.getNumDiffs()).to.equal(1);
+      });
+    });
+
+    it('it shows 0 diffs after merging', () => {
+      cy.get('.acediff__newCodeConnector').click();
+
+      cy.window().then((win) => {
+        expect(win.aceDiffer.getNumDiffs()).to.equal(0);
+      });
+    });
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -172,9 +172,16 @@ AceDiff.prototype = {
       right: 0,
     };
 
-    diff.forEach(function (chunk) {
+    diff.forEach(function (chunk, index, array) {
       const chunkType = chunk[0];
-      const text = chunk[1];
+      let text = chunk[1];
+
+      // Fix for #28 https://github.com/ace-diff/ace-diff/issues/28
+      if (array[index + 1] && text.endsWith('\n') && array[index + 1][1].startsWith('\n')) {
+        text += '\n';
+        diff[index][1] = text;
+        diff[index + 1][1] = diff[index + 1][1].replace(/^\n/, '');
+      }
 
       // oddly, occasionally the algorithm returns a diff with no changes made
       if (text.length === 0) {

--- a/test/fixtures/complex-merge.html
+++ b/test/fixtures/complex-merge.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Ace-diff - Test page</title>
+  <link rel="stylesheet" href="../../dist/ace-diff.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.8/ace.js" type="text/javascript" charset="utf-8"></script>
+  <script src="../../dist/ace-diff.min.js"></script>
+</head>
+
+<body>
+  <div class="custom"></div>
+
+  <script>
+    var aceDiffer = new AceDiff({
+      element: '.custom',
+      left: {
+        content: `start
+
+something else
+
+end`,
+      },
+      right: {
+        content: `starts
+mid
+end`,
+      },
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
Fix #28 

Although I'm not happy with it, haven't came up with a better way to resolve this, as the issue originates in the diff-match-patch results.