### PR TITLE
Update normalizeContent.js

### DIFF
--- a/src/helpers/normalizeContent.js
+++ b/src/helpers/normalizeContent.js
@@ -1,4 +1,4 @@
-export default function normalizeContent(value = '') {
-  const normalized = value.replace(/\r\n/g, '\n');
-  return normalized;
+export default function normalizeContent(defaultValue) {
+  const value = (defaultValue === undefined) ? '' : defaultValue;
+  return value.replace(/\r\n/g, '\n');
 }


### PR DESCRIPTION
`ng build --prod` fails with es5 target
@JackuB would you be able to merge this if it looks good to you? 
Error on `ng build --prod`:
```
ERROR in vendor.7608684e3314279a567f.bundle.js from UglifyJs
Unexpected token operator «=», expected punc «,» [/home/vagrant/okta/conductor/conductor-ui/node_modules/ace-diff/src/helpers/normalizeContent.js:1,0][vendor.7608684e3314279a567f.bundle.js:236492,32]
``` 
