### PR TITLE
Fix removing resize event handler when multiple instances of AceDiff are created/disposed at the same time

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -269,11 +269,10 @@ AceDiff.prototype = {
     oldDiv.parentNode.replaceChild(newDiv, oldDiv);
 
     document.getElementById(this.options.classes.gutterID).innerHTML = '';
-    removeEventHandlers();
+    this.removeEventHandlers();
   },
 };
 
-let removeEventHandlers = () => { };
 
 function addEventHandlers(acediff) {
   acediff.editors.left.ace.getSession().on('changeScrollTop', throttle(() => { updateGap(acediff); }, 16));
@@ -302,7 +301,7 @@ function addEventHandlers(acediff) {
   }, 250);
 
   window.addEventListener('resize', onResize);
-  removeEventHandlers = () => {
+  acediff.removeEventHandlers = () => {
     window.removeEventListener('resize', onResize);
   };
 }


### PR DESCRIPTION
When multiple instances are created and exist at the same time, the module `removeEventHandlers` would only contain the `onResize` handler for the last instance created, causing the `removeEventListener` in `destroy()` leaving behind the listeners from the earlier instances.

This then triggers console errors `Cannot read property 'offsetHeight' of null`, caused by the stray `onResize` handlers being called with the Ace instance DOM element no longer existing.

The fix simply keeps the `removeEventHandlers` with the AceEditor instance rather than on the shared module variable.

Fixes #64 