### PR TITLE
fix destroy() to exec removeEventHandlers() even if the gutter is already gone

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -268,7 +268,10 @@ AceDiff.prototype = {
     newDiv.textContent = rightValue;
     oldDiv.parentNode.replaceChild(newDiv, oldDiv);
 
-    document.getElementById(this.options.classes.gutterID).innerHTML = '';
+    const elementById = document.getElementById(this.options.classes.gutterID);
+    if (elementById) {
+      elementById.innerHTML = '';
+    }
     removeEventHandlers();
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -272,11 +272,9 @@ AceDiff.prototype = {
     if (elementById) {
       elementById.innerHTML = '';
     }
-    removeEventHandlers();
+    this.removeEventHandlers();
   },
 };
-
-let removeEventHandlers = () => { };
 
 function addEventHandlers(acediff) {
   acediff.editors.left.ace.getSession().on('changeScrollTop', throttle(() => { updateGap(acediff); }, 16));
@@ -305,7 +303,7 @@ function addEventHandlers(acediff) {
   }, 250);
 
   window.addEventListener('resize', onResize);
-  removeEventHandlers = () => {
+  acediff.removeEventHandlers = () => {
     window.removeEventListener('resize', onResize);
   };
 }


### PR DESCRIPTION
since we are using ace-diff in a modal-panel it might happen, that the destroy() methods is trying to adjust the gutter even though it might not be present in the DOM. By adding a defensive mechanism we ensure that the removeEventListener() method is called for sure.