### PR TITLE
Fix endless loop on src/helpers/merge.js:23

### DIFF
--- a/src/helpers/merge.js
+++ b/src/helpers/merge.js
@@ -22,7 +22,9 @@ export default function merge(target, source) {
         if (!target[key] || !isObject(target[key])) {
           target[key] = source[key]
         }
-        merge(target[key], source[key])
+        if (target[key] != source[key]) {
+          merge(target[key], source[key]);
+        }
       } else {
         Object.assign(target, { [key]: source[key] })
       }


### PR DESCRIPTION
When attempting to use AceDiff, merge keeps throwing the following exception in the web browser console:

![Screenshot from 2025-07-09 15-12-27](https://github.com/user-attachments/assets/26e1a2eb-76bf-48a7-bb59-35dd2d4c5341)

This shows the infinite loop.  By adding a basic comparison, it removes this loop.

Details:
Operating System: Ubuntu Linux 24.04.2 LTS
Web Browser:  Google Chrome
Web Browser Version 138.0.7204.100 (Official Build) (64-bit)